### PR TITLE
Use realloc with os_mremap for nuttx

### DIFF
--- a/core/shared/platform/nuttx/nuttx_platform.c
+++ b/core/shared/platform/nuttx/nuttx_platform.c
@@ -89,6 +89,13 @@ os_mmap(void *hint, size_t size, int prot, int flags, os_file_handle file)
     return p;
 }
 
+void *
+os_mremap(void *old_addr, size_t old_size, size_t new_size)
+{
+    (void)old_size;
+    return realloc(old_addr, new_size);
+}
+
 void
 os_munmap(void *addr, size_t size)
 {

--- a/product-mini/platforms/nuttx/wamr.mk
+++ b/product-mini/platforms/nuttx/wamr.mk
@@ -430,7 +430,6 @@ CSRCS += nuttx_platform.c \
          posix_thread.c \
          posix_time.c \
          posix_sleep.c \
-         mremap.c \
          mem_alloc.c \
          ems_kfc.c \
          ems_alloc.c \


### PR DESCRIPTION
Fix malloc() failed issue when aot_enlarge_memory